### PR TITLE
Fix var name overlapping

### DIFF
--- a/source/Plugin/QualityHls/QualityHlsSettingItem.js
+++ b/source/Plugin/QualityHls/QualityHlsSettingItem.js
@@ -57,12 +57,10 @@ class QualityHlsSettingItem extends SettingOptionItem {
     const entries = [
       ...this.levels
         .map(({ height, width }) => {
-          if (width < height) {
-            height = width;
-          }
+          const quality = (width < height) ? width : height;
 
           return {
-            label: this.localize(`${height}p`),
+            label: this.localize(`${quality}p`),
             value: height,
             default: false
           };


### PR DESCRIPTION
Only overwrite `label` not `value`,
otherwise it will cause an error.